### PR TITLE
Fix: Correct KaTeX delimiters in HTML files

### DIFF
--- a/recursos/listas/PROBABILIDADE-IMP.html
+++ b/recursos/listas/PROBABILIDADE-IMP.html
@@ -146,16 +146,16 @@
   <h3>Problemas Introdutórios</h3>
   <ol>
     <li>
-      <p><strong>Solução:</strong> O número total de bolas é $5 + 3 + 2 = 10$. O número de bolas azuis é 5. A probabilidade é a razão entre o número de casos favoráveis e o número total de casos.
+      <p><strong>Solução:</strong> O número total de bolas é @5 + 3 + 2 = 10@. O número de bolas azuis é 5. A probabilidade é a razão entre o número de casos favoráveis e o número total de casos.
       @@ P(\text{azul}) = \frac{\text{Número de bolas azuis}}{\text{Número total de bolas}} @@
       @@ P(\text{azul}) = \frac{5}{10} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@ ou 50%.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@ ou 50%.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um dado comum tem 6 faces, numeradas de 1 a 6. O número total de resultados possíveis é 6. O resultado favorável é obter o número 4, que é apenas 1 caso.
       @@ P(obter 4) = \frac{\text{Número de faces com 4}}{\text{Número total de faces}} @@
       @@ P(obter 4) = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> A previsão de 70% de chance de chover significa que a probabilidade é de 0.70.
@@ -166,19 +166,19 @@
       <p><strong>Solução:</strong> Os resultados possíveis para duas moedas são: (Cara, Cara), (Cara, Coroa), (Coroa, Cara), (Coroa, Coroa). Total de 4 resultados possíveis. O resultado favorável é (Cara, Cara), que é 1 caso.
       @@ P(\text{Cara, Cara}) = \frac{\text{Número de vezes que ocorre (Cara, Cara)}}{\text{Número total de resultados}} @@
       @@ P(\text{Cara, Cara}) = \frac{1}{4} @@
-      <strong>Resposta:</strong> @$\frac{1}{4}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{4}@.</p>
     </li>
     <li>
-      <p><strong>Solução:</strong> O número total de lâmpadas é 10. O número de lâmpadas defeituosas é 2. Portanto, o número de lâmpadas não defeituosas é $10 - 2 = 8$.
+      <p><strong>Solução:</strong> O número total de lâmpadas é 10. O número de lâmpadas defeituosas é 2. Portanto, o número de lâmpadas não defeituosas é @10 - 2 = 8@.
       @@ P(\text{não defeituosa}) = \frac{\text{Número de lâmpadas não defeituosas}}{\text{Número total de lâmpadas}} @@
       @@ P(\text{não defeituosa}) = \frac{8}{10} = \frac{4}{5} @@
-      <strong>Resposta:</strong> @$\frac{4}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{4}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um baralho comum tem 52 cartas. Há 4 Ases no baralho (um de cada naipe).
       @@ P(\text{retirar um Ás}) = \frac{\text{Número de Ases}}{\text{Número total de cartas}} @@
       @@ P(\text{retirar um Ás}) = \frac{4}{52} = \frac{1}{13} @@
-      <strong>Resposta:</strong> @$\frac{1}{13}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{13}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um evento impossível é aquele que não pode ocorrer. Sua probabilidade é sempre 0.
@@ -189,28 +189,28 @@
       <strong>Resposta:</strong> 1.</p>
     </li>
     <li>
-      <p><strong>Solução:</strong> O número total de alunos é 30. O número de meninas é 18. O número de meninos é $30 - 18 = 12$.
+      <p><strong>Solução:</strong> O número total de alunos é 30. O número de meninas é 18. O número de meninos é @30 - 18 = 12@.
       @@ P(\text{escolher um menino}) = \frac{\text{Número de meninos}}{\text{Número total de alunos}} @@
       @@ P(\text{escolher um menino}) = \frac{12}{30} = \frac{2}{5} @@
-      <strong>Resposta:</strong> @$\frac{2}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{2}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Os números entre 1 e 10 são {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}. O total de números é 10. Os números pares são {2, 4, 6, 8, 10}, totalizando 5 números.
       @@ P(\text{número par}) = \frac{\text{Número de números pares}}{\text{Número total de números}} @@
       @@ P(\text{número par}) = \frac{5}{10} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> O número total de números no sorteio é 100. Você comprou 5 números.
       @@ P(\text{ganhar}) = \frac{\text{Número de números comprados}}{\text{Número total de números}} @@
       @@ P(\text{ganhar}) = \frac{5}{100} = \frac{1}{20} @@
-      <strong>Resposta:</strong> @$\frac{1}{20}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{20}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> A roleta tem 8 setores iguais. Os números ímpares são {1, 3, 5, 7}, totalizando 4 números.
       @@ P(\text{número ímpar}) = \frac{\text{Número de setores com números ímpares}}{\text{Número total de setores}} @@
       @@ P(\text{número ímpar}) = \frac{4}{8} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
   </ol>
 
@@ -218,32 +218,32 @@
   <ol>
     <li>
       <p><strong>Solução:</strong>
-      O número total de bolas é $6 + 4 = 10$.
-      A probabilidade de a primeira bola ser vermelha é $P(V_1) = \frac{6}{10}$.
+      O número total de bolas é @6 + 4 = 10@.
+      A probabilidade de a primeira bola ser vermelha é @P(V_1) = \frac{6}{10}@.
       Após retirar uma bola vermelha, restam 5 bolas vermelhas e 4 bolas azuis, totalizando 9 bolas.
-      A probabilidade de a segunda bola ser vermelha, dado que a primeira foi vermelha, é $P(V_2|V_1) = \frac{5}{9}$.
+      A probabilidade de a segunda bola ser vermelha, dado que a primeira foi vermelha, é @P(V_2|V_1) = \frac{5}{9}@.
       A probabilidade de ambas serem vermelhas é o produto dessas probabilidades:
       @@ P(V_1 \cap V_2) = P(V_1) \times P(V_2|V_1) @@
       @@ P(V_1 \cap V_2) = \frac{6}{10} \times \frac{5}{9} = \frac{30}{90} = \frac{1}{3} @@
-      <strong>Resposta:</strong> @$\frac{1}{3}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{3}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      O número total de bolas é $5 + 3 + 2 = 10$.
+      O número total de bolas é @5 + 3 + 2 = 10@.
       Queremos a probabilidade de a bola ser branca OU verde. Como esses eventos são mutuamente exclusivos (uma bola não pode ser branca e verde ao mesmo tempo), somamos suas probabilidades.
       @@ P(\text{branca ou verde}) = P(\text{branca}) + P(\text{verde}) @@
       @@ P(\text{branca}) = \frac{5}{10} @@
       @@ P(\text{verde}) = \frac{2}{10} @@
       @@ P(\text{branca ou verde}) = \frac{5}{10} + \frac{2}{10} = \frac{7}{10} @@
-      <strong>Resposta:</strong> @$\frac{7}{10}$@.</p>
+      <strong>Resposta:</strong> @\frac{7}{10}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Ao lançar dois dados, o número total de resultados possíveis é $6 \times 6 = 36$.
+      Ao lançar dois dados, o número total de resultados possíveis é @6 \times 6 = 36@.
       Os pares que somam 7 são: (1, 6), (2, 5), (3, 4), (4, 3), (5, 2), (6, 1). São 6 pares favoráveis.
       @@ P(\text{soma 7}) = \frac{\text{Número de pares que somam 7}}{\text{Número total de resultados}} @@
       @@ P(\text{soma 7}) = \frac{6}{36} = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -256,7 +256,7 @@
       A probabilidade de escolher aleatoriamente uma pessoa que gosta apenas de futebol é:
       @@ P(\text{apenas F}) = \frac{\text{Número de pessoas que gostam apenas de futebol}}{\text{Número total de pessoas}} @@
       @@ P(\text{apenas F}) = \frac{20}{50} = \frac{2}{5} @@
-      <strong>Resposta:</strong> @$\frac{2}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{2}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -267,15 +267,15 @@
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Os resultados possíveis ao lançar uma moeda 3 vezes são $2^3 = 8$.
+      Os resultados possíveis ao lançar uma moeda 3 vezes são @2^3 = 8@.
       Os resultados com exatamente duas caras são: (C, C, K), (C, K, C), (K, C, C). São 3 resultados favoráveis.
       @@ P(\text{exatamente 2 caras}) = \frac{\text{Número de resultados com 2 caras}}{\text{Número total de resultados}} @@
       @@ P(\text{exatamente 2 caras}) = \frac{3}{8} @@
-      <strong>Resposta:</strong> @$\frac{3}{8}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{8}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      A probabilidade de um produto NÃO ser defeituoso é $1 - 0.05 = 0.95$.
+      A probabilidade de um produto NÃO ser defeituoso é @1 - 0.05 = 0.95@.
       Para que nenhum dos 10 produtos seja defeituoso, cada um deles deve ser não defeituoso. Como os eventos são independentes, multiplicamos as probabilidades.
       @@ P(\text{nenhum defeituoso em 10}) = (0.95)^{10} @@
       @@ (0.95)^{10} \approx 0.5987 @@
@@ -288,7 +288,7 @@
       As figuras de copas são: V de Copas, D de Copas, R de Copas. São 3 cartas.
       @@ P(\text{figura de copas}) = \frac{\text{Número de figuras de copas}}{\text{Número total de cartas}} @@
       @@ P(\text{figura de copas}) = \frac{3}{52} @@
-      <strong>Resposta:</strong> @$\frac{3}{52}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{52}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -304,14 +304,14 @@
     <li>
       <p><strong>Solução:</strong>
       Total de bolas = 7.
-      O número total de pares de bolas que podem ser retiradas sem reposição é $\binom{7}{2} = \frac{7 \times 6}{2} = 21$.
+      O número total de pares de bolas que podem ser retiradas sem reposição é @\binom{7}{2} = \frac{7 \times 6}{2} = 21@.
       Para que a soma seja par, as duas bolas devem ser ambas pares ou ambas ímpares.
-      Bolas pares: {2, 4, 6} (3 bolas). Número de pares de bolas pares: $\binom{3}{2} = 3$.
-      Bolas ímpares: {1, 3, 5, 7} (4 bolas). Número de pares de bolas ímpares: $\binom{4}{2} = \frac{4 \times 3}{2} = 6$.
-      Número total de pares favoráveis = $3 + 6 = 9$.
+      Bolas pares: {2, 4, 6} (3 bolas). Número de pares de bolas pares: @\binom{3}{2} = 3@.
+      Bolas ímpares: {1, 3, 5, 7} (4 bolas). Número de pares de bolas ímpares: @\binom{4}{2} = \frac{4 \times 3}{2} = 6@.
+      Número total de pares favoráveis = @3 + 6 = 9@.
       @@ P(\text{soma par}) = \frac{\text{Número de pares favoráveis}}{\text{Número total de pares}} @@
       @@ P(\text{soma par}) = \frac{9}{21} = \frac{3}{7} @@
-      <strong>Resposta:</strong> @$\frac{3}{7}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{7}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -324,12 +324,12 @@
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Seja $L_i$ o evento de a caixa $i$ estar livre.
-      $P(L_1) = 0.8$, $P(L_2) = 0.7$, $P(L_3) = 0.9$.
-      A probabilidade de a caixa $i$ estar ocupada é $P(O_i) = 1 - P(L_i)$.
-      $P(O_1) = 1 - 0.8 = 0.2$
-      $P(O_2) = 1 - 0.7 = 0.3$
-      $P(O_3) = 1 - 0.9 = 0.1$
+      Seja @L_i@ o evento de a caixa @i@ estar livre.
+      @P(L_1) = 0.8@, @P(L_2) = 0.7@, @P(L_3) = 0.9@.
+      A probabilidade de a caixa @i@ estar ocupada é @P(O_i) = 1 - P(L_i)@.
+      @P(O_1) = 1 - 0.8 = 0.2@
+      @P(O_2) = 1 - 0.7 = 0.3@
+      @P(O_3) = 1 - 0.9 = 0.1@
       A probabilidade de que pelo menos uma caixa esteja livre é 1 menos a probabilidade de que todas as caixas estejam ocupadas. Assumindo independência:
       @@ P(\text{todas ocupadas}) = P(O_1) \times P(O_2) \times P(O_3) @@
       @@ P(\text{todas ocupadas}) = 0.2 \times 0.3 \times 0.1 = 0.006 @@
@@ -341,14 +341,14 @@
       <p><strong>Solução:</strong>
       Total de bolas = 10 (5 brancas, 5 pretas).
       Retiram-se 3 bolas sem reposição.
-      O número total de maneiras de retirar 3 bolas de 10 é $\binom{10}{3} = \frac{10 \times 9 \times 8}{3 \times 2 \times 1} = 120$.
+      O número total de maneiras de retirar 3 bolas de 10 é @\binom{10}{3} = \frac{10 \times 9 \times 8}{3 \times 2 \times 1} = 120@.
       Para que todas as 3 bolas sejam da mesma cor, elas podem ser:
-      a) Todas brancas: $\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10$ maneiras.
-      b) Todas pretas: $\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10$ maneiras.
-      O número total de casos favoráveis é $10 + 10 = 20$.
+      a) Todas brancas: @\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10@ maneiras.
+      b) Todas pretas: @\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10@ maneiras.
+      O número total de casos favoráveis é @10 + 10 = 20@.
       @@ P(\text{3 da mesma cor}) = \frac{\text{Número de casos favoráveis}}{\text{Número total de casos}} @@
       @@ P(\text{3 da mesma cor}) = \frac{20}{120} = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -362,7 +362,7 @@
       @@ P(\text{múltiplo de 3}) = \frac{4}{10} @@
       @@ P(\text{primo E múltiplo de 3}) = P(3) = \frac{1}{10} @@
       @@ P(\text{primo ou múltiplo de 3}) = \frac{4}{10} + \frac{4}{10} - \frac{1}{10} = \frac{7}{10} @@
-      <strong>Resposta:</strong> @$\frac{7}{10}$@.</p>
+      <strong>Resposta:</strong> @\frac{7}{10}@.</p>
     </li>
   </ol>
 
@@ -388,7 +388,7 @@
       Se a primeira bola retirada foi vermelha, restam na urna: 2 bolas vermelhas e 2 bolas azuis. Total = 4 bolas.
       @@ P(\text{2ª V | 1ª V}) = \frac{\text{Número de bolas vermelhas restantes}}{\text{Número total de bolas restantes}} @@
       @@ P(\text{2ª V | 1ª V}) = \frac{2}{4} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -411,12 +411,12 @@
     <li>
       <p><strong>Solução:</strong>
       Um baralho tem 52 cartas. Queremos a probabilidade de receber exatamente 2 Ases em uma mão de 5 cartas.
-      O número total de maneiras de escolher 5 cartas de 52 é $\binom{52}{5}$.
+      O número total de maneiras de escolher 5 cartas de 52 é @\binom{52}{5}@.
       @@ \binom{52}{5} = \frac{52 \times 51 \times 50 \times 49 \times 48}{5 \times 4 \times 3 \times 2 \times 1} = 2.598.960 @@
       Para ter exatamente 2 Ases, precisamos escolher 2 Ases de 4 disponíveis e 3 cartas não Ases de 48 restantes.
-      Número de maneiras de escolher 2 Ases: $\binom{4}{2} = \frac{4 \times 3}{2 \times 1} = 6$.
-      Número de maneiras de escolher 3 cartas não Ases: $\binom{48}{3} = \frac{48 \times 47 \times 46}{3 \times 2 \times 1} = 17.296$.
-      O número total de mãos com exatamente 2 Ases é $\binom{4}{2} \times \binom{48}{3} = 6 \times 17.296 = 103.776$.
+      Número de maneiras de escolher 2 Ases: @\binom{4}{2} = \frac{4 \times 3}{2 \times 1} = 6@.
+      Número de maneiras de escolher 3 cartas não Ases: @\binom{48}{3} = \frac{48 \times 47 \times 46}{3 \times 2 \times 1} = 17.296@.
+      O número total de mãos com exatamente 2 Ases é @\binom{4}{2} \times \binom{48}{3} = 6 \times 17.296 = 103.776@.
       A probabilidade é:
       @@ P(\text{exatamente 2 Ases}) = \frac{\text{Número de mãos com 2 Ases}}{\text{Número total de mãos de 5 cartas}} @@
       @@ P(\text{exatamente 2 Ases}) = \frac{103.776}{2.598.960} \approx 0.0399 @@
@@ -439,14 +439,14 @@
     <li>
       <p><strong>Solução:</strong>
       Este problema pode ser modelado usando a distribuição binomial.
-      Número de tentativas (parafusos na caixa), $n = 100$.
-      Probabilidade de sucesso (parafuso ser defeituoso), $p = 0.01$.
-      Probabilidade de fracasso (parafuso não ser defeituoso), $q = 1 - p = 0.99$.
-      Queremos a probabilidade de ter exatamente $k=2$ parafusos defeituosos. A fórmula da probabilidade binomial é:
+      Número de tentativas (parafusos na caixa), @n = 100@.
+      Probabilidade de sucesso (parafuso ser defeituoso), @p = 0.01@.
+      Probabilidade de fracasso (parafuso não ser defeituoso), @q = 1 - p = 0.99@.
+      Queremos a probabilidade de ter exatamente @k=2@ parafusos defeituosos. A fórmula da probabilidade binomial é:
       @@ P(X=k) = \binom{n}{k} p^k q^{n-k} @@
       @@ P(X=2) = \binom{100}{2} (0.01)^2 (0.99)^{100-2} @@
       @@ P(X=2) = \binom{100}{2} (0.01)^2 (0.99)^{98} @@
-      Calculando $\binom{100}{2}$:
+      Calculando @\binom{100}{2}@:
       @@ \binom{100}{2} = \frac{100 \times 99}{2 \times 1} = 4950 @@
       Agora, calculamos a probabilidade:
       @@ P(X=2) = 4950 \times (0.0001) \times (0.99)^{98} @@

--- a/recursos/listas/PROBABILIDADE.html
+++ b/recursos/listas/PROBABILIDADE.html
@@ -148,16 +148,16 @@
   <h3>Problemas Introdutórios</h3>
   <ol>
     <li>
-      <p><strong>Solução:</strong> O número total de bolas é $5 + 3 + 2 = 10$. O número de bolas azuis é 5. A probabilidade é a razão entre o número de casos favoráveis e o número total de casos.
+      <p><strong>Solução:</strong> O número total de bolas é @5 + 3 + 2 = 10@. O número de bolas azuis é 5. A probabilidade é a razão entre o número de casos favoráveis e o número total de casos.
       @@ P(\text{azul}) = \frac{\text{Número de bolas azuis}}{\text{Número total de bolas}} @@
       @@ P(\text{azul}) = \frac{5}{10} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@ ou 50%.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@ ou 50%.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um dado comum tem 6 faces, numeradas de 1 a 6. O número total de resultados possíveis é 6. O resultado favorável é obter o número 4, que é apenas 1 caso.
       @@ P(obter 4) = \frac{\text{Número de faces com 4}}{\text{Número total de faces}} @@
       @@ P(obter 4) = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> A previsão de 70% de chance de chover significa que a probabilidade é de 0.70.
@@ -168,19 +168,19 @@
       <p><strong>Solução:</strong> Os resultados possíveis para duas moedas são: (Cara, Cara), (Cara, Coroa), (Coroa, Cara), (Coroa, Coroa). Total de 4 resultados possíveis. O resultado favorável é (Cara, Cara), que é 1 caso.
       @@ P(\text{Cara, Cara}) = \frac{\text{Número de vezes que ocorre (Cara, Cara)}}{\text{Número total de resultados}} @@
       @@ P(\text{Cara, Cara}) = \frac{1}{4} @@
-      <strong>Resposta:</strong> @$\frac{1}{4}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{4}@.</p>
     </li>
     <li>
-      <p><strong>Solução:</strong> O número total de lâmpadas é 10. O número de lâmpadas defeituosas é 2. Portanto, o número de lâmpadas não defeituosas é $10 - 2 = 8$.
+      <p><strong>Solução:</strong> O número total de lâmpadas é 10. O número de lâmpadas defeituosas é 2. Portanto, o número de lâmpadas não defeituosas é @10 - 2 = 8@.
       @@ P(\text{não defeituosa}) = \frac{\text{Número de lâmpadas não defeituosas}}{\text{Número total de lâmpadas}} @@
       @@ P(\text{não defeituosa}) = \frac{8}{10} = \frac{4}{5} @@
-      <strong>Resposta:</strong> @$\frac{4}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{4}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um baralho comum tem 52 cartas. Há 4 Ases no baralho (um de cada naipe).
       @@ P(\text{retirar um Ás}) = \frac{\text{Número de Ases}}{\text{Número total de cartas}} @@
       @@ P(\text{retirar um Ás}) = \frac{4}{52} = \frac{1}{13} @@
-      <strong>Resposta:</strong> @$\frac{1}{13}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{13}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Um evento impossível é aquele que não pode ocorrer. Sua probabilidade é sempre 0.
@@ -191,28 +191,28 @@
       <strong>Resposta:</strong> 1.</p>
     </li>
     <li>
-      <p><strong>Solução:</strong> O número total de alunos é 30. O número de meninas é 18. O número de meninos é $30 - 18 = 12$.
+      <p><strong>Solução:</strong> O número total de alunos é 30. O número de meninas é 18. O número de meninos é @30 - 18 = 12@.
       @@ P(\text{escolher um menino}) = \frac{\text{Número de meninos}}{\text{Número total de alunos}} @@
       @@ P(\text{escolher um menino}) = \frac{12}{30} = \frac{2}{5} @@
-      <strong>Resposta:</strong> @$\frac{2}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{2}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> Os números entre 1 e 10 são {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}. O total de números é 10. Os números pares são {2, 4, 6, 8, 10}, totalizando 5 números.
       @@ P(\text{número par}) = \frac{\text{Número de números pares}}{\text{Número total de números}} @@
       @@ P(\text{número par}) = \frac{5}{10} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> O número total de números no sorteio é 100. Você comprou 5 números.
       @@ P(\text{ganhar}) = \frac{\text{Número de números comprados}}{\text{Número total de números}} @@
       @@ P(\text{ganhar}) = \frac{5}{100} = \frac{1}{20} @@
-      <strong>Resposta:</strong> @$\frac{1}{20}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{20}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong> A roleta tem 8 setores iguais. Os números ímpares são {1, 3, 5, 7}, totalizando 4 números.
       @@ P(\text{número ímpar}) = \frac{\text{Número de setores com números ímpares}}{\text{Número total de setores}} @@
       @@ P(\text{número ímpar}) = \frac{4}{8} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
   </ol>
 
@@ -220,32 +220,32 @@
   <ol>
     <li>
       <p><strong>Solução:</strong>
-      O número total de bolas é $6 + 4 = 10$.
-      A probabilidade de a primeira bola ser vermelha é $P(V_1) = \frac{6}{10}$.
+      O número total de bolas é @6 + 4 = 10@.
+      A probabilidade de a primeira bola ser vermelha é @P(V_1) = \frac{6}{10}@.
       Após retirar uma bola vermelha, restam 5 bolas vermelhas e 4 bolas azuis, totalizando 9 bolas.
-      A probabilidade de a segunda bola ser vermelha, dado que a primeira foi vermelha, é $P(V_2|V_1) = \frac{5}{9}$.
+      A probabilidade de a segunda bola ser vermelha, dado que a primeira foi vermelha, é @P(V_2|V_1) = \frac{5}{9}@.
       A probabilidade de ambas serem vermelhas é o produto dessas probabilidades:
       @@ P(V_1 \cap V_2) = P(V_1) \times P(V_2|V_1) @@
       @@ P(V_1 \cap V_2) = \frac{6}{10} \times \frac{5}{9} = \frac{30}{90} = \frac{1}{3} @@
-      <strong>Resposta:</strong> @$\frac{1}{3}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{3}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      O número total de bolas é $5 + 3 + 2 = 10$.
+      O número total de bolas é @5 + 3 + 2 = 10@.
       Queremos a probabilidade de a bola ser branca OU verde. Como esses eventos são mutuamente exclusivos (uma bola não pode ser branca e verde ao mesmo tempo), somamos suas probabilidades.
       @@ P(\text{branca ou verde}) = P(\text{branca}) + P(\text{verde}) @@
       @@ P(\text{branca}) = \frac{5}{10} @@
       @@ P(\text{verde}) = \frac{2}{10} @@
       @@ P(\text{branca ou verde}) = \frac{5}{10} + \frac{2}{10} = \frac{7}{10} @@
-      <strong>Resposta:</strong> @$\frac{7}{10}$@.</p>
+      <strong>Resposta:</strong> @\frac{7}{10}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Ao lançar dois dados, o número total de resultados possíveis é $6 \times 6 = 36$.
+      Ao lançar dois dados, o número total de resultados possíveis é @6 \times 6 = 36@.
       Os pares que somam 7 são: (1, 6), (2, 5), (3, 4), (4, 3), (5, 2), (6, 1). São 6 pares favoráveis.
       @@ P(\text{soma 7}) = \frac{\text{Número de pares que somam 7}}{\text{Número total de resultados}} @@
       @@ P(\text{soma 7}) = \frac{6}{36} = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -258,7 +258,7 @@
       A probabilidade de escolher aleatoriamente uma pessoa que gosta apenas de futebol é:
       @@ P(\text{apenas F}) = \frac{\text{Número de pessoas que gostam apenas de futebol}}{\text{Número total de pessoas}} @@
       @@ P(\text{apenas F}) = \frac{20}{50} = \frac{2}{5} @@
-      <strong>Resposta:</strong> @$\frac{2}{5}$@.</p>
+      <strong>Resposta:</strong> @\frac{2}{5}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -269,15 +269,15 @@
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Os resultados possíveis ao lançar uma moeda 3 vezes são $2^3 = 8$.
+      Os resultados possíveis ao lançar uma moeda 3 vezes são @2^3 = 8@.
       Os resultados com exatamente duas caras são: (C, C, K), (C, K, C), (K, C, C). São 3 resultados favoráveis.
       @@ P(\text{exatamente 2 caras}) = \frac{\text{Número de resultados com 2 caras}}{\text{Número total de resultados}} @@
       @@ P(\text{exatamente 2 caras}) = \frac{3}{8} @@
-      <strong>Resposta:</strong> @$\frac{3}{8}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{8}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
-      A probabilidade de um produto NÃO ser defeituoso é $1 - 0.05 = 0.95$.
+      A probabilidade de um produto NÃO ser defeituoso é @1 - 0.05 = 0.95@.
       Para que nenhum dos 10 produtos seja defeituoso, cada um deles deve ser não defeituoso. Como os eventos são independentes, multiplicamos as probabilidades.
       @@ P(\text{nenhum defeituoso em 10}) = (0.95)^{10} @@
       @@ (0.95)^{10} \approx 0.5987 @@
@@ -290,7 +290,7 @@
       As figuras de copas são: V de Copas, D de Copas, R de Copas. São 3 cartas.
       @@ P(\text{figura de copas}) = \frac{\text{Número de figuras de copas}}{\text{Número total de cartas}} @@
       @@ P(\text{figura de copas}) = \frac{3}{52} @@
-      <strong>Resposta:</strong> @$\frac{3}{52}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{52}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -306,14 +306,14 @@
     <li>
       <p><strong>Solução:</strong>
       Total de bolas = 7.
-      O número total de pares de bolas que podem ser retiradas sem reposição é $\binom{7}{2} = \frac{7 \times 6}{2} = 21$.
+      O número total de pares de bolas que podem ser retiradas sem reposição é @\binom{7}{2} = \frac{7 \times 6}{2} = 21@.
       Para que a soma seja par, as duas bolas devem ser ambas pares ou ambas ímpares.
-      Bolas pares: {2, 4, 6} (3 bolas). Número de pares de bolas pares: $\binom{3}{2} = 3$.
-      Bolas ímpares: {1, 3, 5, 7} (4 bolas). Número de pares de bolas ímpares: $\binom{4}{2} = \frac{4 \times 3}{2} = 6$.
-      Número total de pares favoráveis = $3 + 6 = 9$.
+      Bolas pares: {2, 4, 6} (3 bolas). Número de pares de bolas pares: @\binom{3}{2} = 3@.
+      Bolas ímpares: {1, 3, 5, 7} (4 bolas). Número de pares de bolas ímpares: @\binom{4}{2} = \frac{4 \times 3}{2} = 6@.
+      Número total de pares favoráveis = @3 + 6 = 9@.
       @@ P(\text{soma par}) = \frac{\text{Número de pares favoráveis}}{\text{Número total de pares}} @@
       @@ P(\text{soma par}) = \frac{9}{21} = \frac{3}{7} @@
-      <strong>Resposta:</strong> @$\frac{3}{7}$@.</p>
+      <strong>Resposta:</strong> @\frac{3}{7}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -326,12 +326,12 @@
     </li>
     <li>
       <p><strong>Solução:</strong>
-      Seja $L_i$ o evento de a caixa $i$ estar livre.
-      $P(L_1) = 0.8$, $P(L_2) = 0.7$, $P(L_3) = 0.9$.
-      A probabilidade de a caixa $i$ estar ocupada é $P(O_i) = 1 - P(L_i)$.
-      $P(O_1) = 1 - 0.8 = 0.2$
-      $P(O_2) = 1 - 0.7 = 0.3$
-      $P(O_3) = 1 - 0.9 = 0.1$
+      Seja @L_i@ o evento de a caixa @i@ estar livre.
+      @P(L_1) = 0.8@, @P(L_2) = 0.7@, @P(L_3) = 0.9@.
+      A probabilidade de a caixa @i@ estar ocupada é @P(O_i) = 1 - P(L_i)@.
+      @P(O_1) = 1 - 0.8 = 0.2@
+      @P(O_2) = 1 - 0.7 = 0.3@
+      @P(O_3) = 1 - 0.9 = 0.1@
       A probabilidade de que pelo menos uma caixa esteja livre é 1 menos a probabilidade de que todas as caixas estejam ocupadas. Assumindo independência:
       @@ P(\text{todas ocupadas}) = P(O_1) \times P(O_2) \times P(O_3) @@
       @@ P(\text{todas ocupadas}) = 0.2 \times 0.3 \times 0.1 = 0.006 @@
@@ -343,14 +343,14 @@
       <p><strong>Solução:</strong>
       Total de bolas = 10 (5 brancas, 5 pretas).
       Retiram-se 3 bolas sem reposição.
-      O número total de maneiras de retirar 3 bolas de 10 é $\binom{10}{3} = \frac{10 \times 9 \times 8}{3 \times 2 \times 1} = 120$.
+      O número total de maneiras de retirar 3 bolas de 10 é @\binom{10}{3} = \frac{10 \times 9 \times 8}{3 \times 2 \times 1} = 120@.
       Para que todas as 3 bolas sejam da mesma cor, elas podem ser:
-      a) Todas brancas: $\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10$ maneiras.
-      b) Todas pretas: $\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10$ maneiras.
-      O número total de casos favoráveis é $10 + 10 = 20$.
+      a) Todas brancas: @\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10@ maneiras.
+      b) Todas pretas: @\binom{5}{3} = \frac{5 \times 4 \times 3}{3 \times 2 \times 1} = 10@ maneiras.
+      O número total de casos favoráveis é @10 + 10 = 20@.
       @@ P(\text{3 da mesma cor}) = \frac{\text{Número de casos favoráveis}}{\text{Número total de casos}} @@
       @@ P(\text{3 da mesma cor}) = \frac{20}{120} = \frac{1}{6} @@
-      <strong>Resposta:</strong> @$\frac{1}{6}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{6}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -364,7 +364,7 @@
       @@ P(\text{múltiplo de 3}) = \frac{4}{10} @@
       @@ P(\text{primo E múltiplo de 3}) = P(3) = \frac{1}{10} @@
       @@ P(\text{primo ou múltiplo de 3}) = \frac{4}{10} + \frac{4}{10} - \frac{1}{10} = \frac{7}{10} @@
-      <strong>Resposta:</strong> @$\frac{7}{10}$@.</p>
+      <strong>Resposta:</strong> @\frac{7}{10}@.</p>
     </li>
   </ol>
 
@@ -390,7 +390,7 @@
       Se a primeira bola retirada foi vermelha, restam na urna: 2 bolas vermelhas e 2 bolas azuis. Total = 4 bolas.
       @@ P(\text{2ª V | 1ª V}) = \frac{\text{Número de bolas vermelhas restantes}}{\text{Número total de bolas restantes}} @@
       @@ P(\text{2ª V | 1ª V}) = \frac{2}{4} = \frac{1}{2} @@
-      <strong>Resposta:</strong> @$\frac{1}{2}$@.</p>
+      <strong>Resposta:</strong> @\frac{1}{2}@.</p>
     </li>
     <li>
       <p><strong>Solução:</strong>
@@ -413,12 +413,12 @@
     <li>
       <p><strong>Solução:</strong>
       Um baralho tem 52 cartas. Queremos a probabilidade de receber exatamente 2 Ases em uma mão de 5 cartas.
-      O número total de maneiras de escolher 5 cartas de 52 é $\binom{52}{5}$.
+      O número total de maneiras de escolher 5 cartas de 52 é @\binom{52}{5}@.
       @@ \binom{52}{5} = \frac{52 \times 51 \times 50 \times 49 \times 48}{5 \times 4 \times 3 \times 2 \times 1} = 2.598.960 @@
       Para ter exatamente 2 Ases, precisamos escolher 2 Ases de 4 disponíveis e 3 cartas não Ases de 48 restantes.
-      Número de maneiras de escolher 2 Ases: $\binom{4}{2} = \frac{4 \times 3}{2 \times 1} = 6$.
-      Número de maneiras de escolher 3 cartas não Ases: $\binom{48}{3} = \frac{48 \times 47 \times 46}{3 \times 2 \times 1} = 17.296$.
-      O número total de mãos com exatamente 2 Ases é $\binom{4}{2} \times \binom{48}{3} = 6 \times 17.296 = 103.776$.
+      Número de maneiras de escolher 2 Ases: @\binom{4}{2} = \frac{4 \times 3}{2 \times 1} = 6@.
+      Número de maneiras de escolher 3 cartas não Ases: @\binom{48}{3} = \frac{48 \times 47 \times 46}{3 \times 2 \times 1} = 17.296@.
+      O número total de mãos com exatamente 2 Ases é @\binom{4}{2} \times \binom{48}{3} = 6 \times 17.296 = 103.776@.
       A probabilidade é:
       @@ P(\text{exatamente 2 Ases}) = \frac{\text{Número de mãos com 2 Ases}}{\text{Número total de mãos de 5 cartas}} @@
       @@ P(\text{exatamente 2 Ases}) = \frac{103.776}{2.598.960} \approx 0.0399 @@
@@ -441,14 +441,14 @@
     <li>
       <p><strong>Solução:</strong>
       Este problema pode ser modelado usando a distribuição binomial.
-      Número de tentativas (parafusos na caixa), $n = 100$.
-      Probabilidade de sucesso (parafuso ser defeituoso), $p = 0.01$.
-      Probabilidade de fracasso (parafuso não ser defeituoso), $q = 1 - p = 0.99$.
-      Queremos a probabilidade de ter exatamente $k=2$ parafusos defeituosos. A fórmula da probabilidade binomial é:
+      Número de tentativas (parafusos na caixa), @n = 100@.
+      Probabilidade de sucesso (parafuso ser defeituoso), @p = 0.01@.
+      Probabilidade de fracasso (parafuso não ser defeituoso), @q = 1 - p = 0.99@.
+      Queremos a probabilidade de ter exatamente @k=2@ parafusos defeituosos. A fórmula da probabilidade binomial é:
       @@ P(X=k) = \binom{n}{k} p^k q^{n-k} @@
       @@ P(X=2) = \binom{100}{2} (0.01)^2 (0.99)^{100-2} @@
       @@ P(X=2) = \binom{100}{2} (0.01)^2 (0.99)^{98} @@
-      Calculando $\binom{100}{2}$:
+      Calculando @\binom{100}{2}@:
       @@ \binom{100}{2} = \frac{100 \times 99}{2 \times 1} = 4950 @@
       Agora, calculamos a probabilidade:
       @@ P(X=2) = 4950 \times (0.0001) \times (0.99)^{98} @@

--- a/recursos/resumos/PROBABILIDADE-IMP.html
+++ b/recursos/resumos/PROBABILIDADE-IMP.html
@@ -83,15 +83,15 @@
     P(A \cup B) = P(A) + P(B) - P(A \cap B)
     @@
 
-    <p>Onde $P(A \cap B)$ é a probabilidade de A e B ocorrerem simultaneamente.</p>
+    <p>Onde @P(A \cap B)@ é a probabilidade de A e B ocorrerem simultaneamente.</p>
 
     <h3>Exemplo 3: Lançamento de um dado (eventos não mutuamente exclusivos)</h3>
     <p>Qual a probabilidade de obter um número par OU um número maior que 3 ao lançar um dado?</p>
     <ol>
         <li><strong>Espaço Amostral (Ω):</strong> {1, 2, 3, 4, 5, 6} (total de 6 resultados).</li>
-        <li><strong>Evento A:</strong> Obter um número par. A = {2, 4, 6}. $P(A) = \frac{3}{6} = \frac{1}{2}$.</li>
-        <li><strong>Evento B:</strong> Obter um número maior que 3. B = {4, 5, 6}. $P(B) = \frac{3}{6} = \frac{1}{2}$.</li>
-        <li><strong>Evento A ∩ B:</strong> Obter um número par E maior que 3. A ∩ B = {4, 6}. $P(A \cap B) = \frac{2}{6} = \frac{1}{3}$.</li>
+        <li><strong>Evento A:</strong> Obter um número par. A = {2, 4, 6}. @P(A) = \frac{3}{6} = \frac{1}{2}@.</li>
+        <li><strong>Evento B:</strong> Obter um número maior que 3. B = {4, 5, 6}. @P(B) = \frac{3}{6} = \frac{1}{2}@.</li>
+        <li><strong>Evento A ∩ B:</strong> Obter um número par E maior que 3. A ∩ B = {4, 6}. @P(A \cap B) = \frac{2}{6} = \frac{1}{3}@.</li>
         <li><strong>Calcular P(A ∪ B):</strong>
             @@
             P(A \cup B) = P(A) + P(B) - P(A \cap B) = \frac{1}{2} + \frac{1}{2} - \frac{1}{3} = 1 - \frac{1}{3} = \frac{2}{3}
@@ -111,8 +111,8 @@
     <h3>Exemplo 4: Lançamento de duas moedas</h3>
     <p>Qual a probabilidade de obter cara no primeiro lançamento E coroa no segundo lançamento de uma moeda justa?</p>
     <ol>
-        <li><strong>Evento A:</strong> Obter cara no primeiro lançamento. $P(A) = \frac{1}{2}$.</li>
-        <li><strong>Evento B:</strong> Obter coroa no segundo lançamento. $P(B) = \frac{1}{2}$.</li>
+        <li><strong>Evento A:</strong> Obter cara no primeiro lançamento. @P(A) = \frac{1}{2}@.</li>
+        <li><strong>Evento B:</strong> Obter coroa no segundo lançamento. @P(B) = \frac{1}{2}@.</li>
         <li><strong>Calcular P(A ∩ B):</strong> Como os lançamentos são independentes:
             @@
             P(A \cap B) = P(A) \times P(B) = \frac{1}{2} \times \frac{1}{2} = \frac{1}{4}

--- a/recursos/resumos/PROBABILIDADE.html
+++ b/recursos/resumos/PROBABILIDADE.html
@@ -91,15 +91,15 @@
     P(A \cup B) = P(A) + P(B) - P(A \cap B)
     @@
 
-    <p>Onde $P(A \cap B)$ é a probabilidade de A e B ocorrerem simultaneamente.</p>
+    <p>Onde @P(A \cap B)@ é a probabilidade de A e B ocorrerem simultaneamente.</p>
 
     <h3>Exemplo 3: Lançamento de um dado (eventos não mutuamente exclusivos)</h3>
     <p>Qual a probabilidade de obter um número par OU um número maior que 3 ao lançar um dado?</p>
     <ol>
         <li><strong>Espaço Amostral (Ω):</strong> {1, 2, 3, 4, 5, 6} (total de 6 resultados).</li>
-        <li><strong>Evento A:</strong> Obter um número par. A = {2, 4, 6}. $P(A) = \frac{3}{6} = \frac{1}{2}$.</li>
-        <li><strong>Evento B:</strong> Obter um número maior que 3. B = {4, 5, 6}. $P(B) = \frac{3}{6} = \frac{1}{2}$.</li>
-        <li><strong>Evento A ∩ B:</strong> Obter um número par E maior que 3. A ∩ B = {4, 6}. $P(A \cap B) = \frac{2}{6} = \frac{1}{3}$.</li>
+        <li><strong>Evento A:</strong> Obter um número par. A = {2, 4, 6}. @P(A) = \frac{3}{6} = \frac{1}{2}@.</li>
+        <li><strong>Evento B:</strong> Obter um número maior que 3. B = {4, 5, 6}. @P(B) = \frac{3}{6} = \frac{1}{2}@.</li>
+        <li><strong>Evento A ∩ B:</strong> Obter um número par E maior que 3. A ∩ B = {4, 6}. @P(A \cap B) = \frac{2}{6} = \frac{1}{3}@.</li>
         <li><strong>Calcular P(A ∪ B):</strong>
             @@
             P(A \cup B) = P(A) + P(B) - P(A \cap B) = \frac{1}{2} + \frac{1}{2} - \frac{1}{3} = 1 - \frac{1}{3} = \frac{2}{3}
@@ -119,8 +119,8 @@
     <h3>Exemplo 4: Lançamento de duas moedas</h3>
     <p>Qual a probabilidade de obter cara no primeiro lançamento E coroa no segundo lançamento de uma moeda justa?</p>
     <ol>
-        <li><strong>Evento A:</strong> Obter cara no primeiro lançamento. $P(A) = \frac{1}{2}$.</li>
-        <li><strong>Evento B:</strong> Obter coroa no segundo lançamento. $P(B) = \frac{1}{2}$.</li>
+        <li><strong>Evento A:</strong> Obter cara no primeiro lançamento. @P(A) = \frac{1}{2}@.</li>
+        <li><strong>Evento B:</strong> Obter coroa no segundo lançamento. @P(B) = \frac{1}{2}@.</li>
         <li><strong>Calcular P(A ∩ B):</strong> Como os lançamentos são independentes:
             @@
             P(A \cap B) = P(A) \times P(B) = \frac{1}{2} \times \frac{1}{2} = \frac{1}{4}


### PR DESCRIPTION
Some of the HTML files were using the '$' delimiter for KaTeX expressions instead of the correct '@' delimiter. This commit corrects the delimiter in all affected files.