### PR TITLE
fix(html): Correct stylesheet paths in subpages

### DIFF
--- a/recursos/listas/FUNCAO-1GRAU-IMP.html
+++ b/recursos/listas/FUNCAO-1GRAU-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/listas/FUNCAO-1GRAU.html
+++ b/recursos/listas/FUNCAO-1GRAU.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/listas/GEOMETRIA-PERIMETRO-AREA-IMP.html
+++ b/recursos/listas/GEOMETRIA-PERIMETRO-AREA-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/listas/GEOMETRIA-PERIMETRO-AREA.html
+++ b/recursos/listas/GEOMETRIA-PERIMETRO-AREA.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/listas/PROBABILIDADE-IMP.html
+++ b/recursos/listas/PROBABILIDADE-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/listas/PROBABILIDADE.html
+++ b/recursos/listas/PROBABILIDADE.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/FUNCAO-1GRAU-IMP.html
+++ b/recursos/recuperacao/FUNCAO-1GRAU-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/FUNCAO-1GRAU.html
+++ b/recursos/recuperacao/FUNCAO-1GRAU.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/GEOMETRIA-PERIMETRO-AREA-IMP.html
+++ b/recursos/recuperacao/GEOMETRIA-PERIMETRO-AREA-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/GEOMETRIA-PERIMETRO-AREA.html
+++ b/recursos/recuperacao/GEOMETRIA-PERIMETRO-AREA.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/PROBABILIDADE-IMP.html
+++ b/recursos/recuperacao/PROBABILIDADE-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/recuperacao/PROBABILIDADE.html
+++ b/recursos/recuperacao/PROBABILIDADE.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/FUNCAO-1GRAU-IMP.html
+++ b/recursos/resumos/FUNCAO-1GRAU-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/FUNCAO-1GRAU.html
+++ b/recursos/resumos/FUNCAO-1GRAU.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/GEOMETRIA-PERIMETRO-AREA-IMP.html
+++ b/recursos/resumos/GEOMETRIA-PERIMETRO-AREA-IMP.html
@@ -9,6 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/GEOMETRIA-PERIMETRO-AREA.html
+++ b/recursos/resumos/GEOMETRIA-PERIMETRO-AREA.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/PROBABILIDADE-IMP.html
+++ b/recursos/resumos/PROBABILIDADE-IMP.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>

--- a/recursos/resumos/PROBABILIDADE.html
+++ b/recursos/resumos/PROBABILIDADE.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.css">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.10/dist/contrib/auto-render.min.js"></script>
-  <link rel="stylesheet" href="../../style.css">
+  <link rel="stylesheet" href="../../css/style.css">
 </head>
 
 <body>


### PR DESCRIPTION
The HTML files located in the subdirectories of `recursos/` (`listas`, `recuperacao`, `resumos`) were referencing the main stylesheet with an incorrect relative path (`../../style.css`). This resulted in broken styling on these pages.

This change corrects the path to `../../css/style.css` in all affected files, ensuring that the visual theme is applied correctly across the entire site.

Additionally, some HTML files were missing the stylesheet link altogether. This has been rectified by adding the correct `<link>` tag to the `<head>` section of these files.